### PR TITLE
spaces instead of tabs (cosmetic / consistency)

### DIFF
--- a/json-template/ubuntu.json
+++ b/json-template/ubuntu.json
@@ -1,30 +1,29 @@
 {
-	"brand": "kvm",
-	
-	"disks": [
-		{
-			"image_uuid": "",
-			"boot": true,
-			"model": "virtio",
-			"image_size": 5120
-		}
-	],
+  "brand": "kvm",
+  "disks": [
+    {
+      "image_uuid": "",
+      "boot": true,
+      "model": "virtio",
+      "image_size": 5120
+    }
+  ],
 
-	"ram": "512",
-	"vcpus": "1",
+  "ram": "512",
+  "vcpus": "1",
 
-	"resolvers": ["8.8.8.8"],
-	"nics": [
-		{
-			"nic_tag": "",
-			"ip": "",
-			"netmask": "",
-			"gateway": "",
-			"model": "virtio"
-		}
-	],
+  "resolvers": ["8.8.8.8"],
+  "nics": [
+    {
+      "nic_tag": "",
+      "ip": "",
+      "netmask": "",
+      "gateway": "",
+      "model": "virtio"
+    }
+  ],
 
-	"customer_metadata": {
-		"root_authorized_keys": ""
-	}
+  "customer_metadata": {
+    "root_authorized_keys": ""
+  }
 }


### PR DESCRIPTION
Totally optional PR but this makes both of the json-templates we provide as examples consistent with each other in regards to using 2 spaces instead of 1 tab.  Purely cosmetic.

	modified:   json-template/ubuntu.json